### PR TITLE
Hotfix: Finish the OnBoarding Activity

### DIFF
--- a/app/src/main/java/com/mobileforce/hometeach/ui/OnBoardingActivity.kt
+++ b/app/src/main/java/com/mobileforce/hometeach/ui/OnBoardingActivity.kt
@@ -70,11 +70,13 @@ class OnBoardingActivity : AppCompatActivity() {
 
         skipText.setOnClickListener {
             startActivity(Intent(this, ExploreActivity::class.java))
+            //finish this activity
             finish()
         }
 
         fab.setOnClickListener {
             startActivity(Intent(this, ExploreActivity::class.java))
+            //finish this activity
             finish()
         }
         setPageViewController()


### PR DESCRIPTION
I made the activity to finish when it navigates to the Explore Activity