### PR TITLE
Fix: remove Timer for Splash screen, use launcher theme

### DIFF
--- a/app/src/main/java/com/mobileforce/hometeach/ui/SplashActivity.kt
+++ b/app/src/main/java/com/mobileforce/hometeach/ui/SplashActivity.kt
@@ -3,28 +3,17 @@ package com.mobileforce.hometeach.ui
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.view.Window
-import com.mobileforce.hometeach.R
-import java.util.*
+
 
 class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        //hiding title bar of this activity
-        window.requestFeature(Window.FEATURE_NO_TITLE)
-        setContentView(R.layout.activity_splash)
 
-        Timer().schedule(object: TimerTask(){
-            override fun run() {
-                //start OnBoarding activity
-                val intent = Intent(this@SplashActivity, ExploreActivity::class.java)
-                startActivity(intent)
-                //finish this activity
-                finish()
-            }
-
-        }, 3000L)
-
+        //start OnBoarding activity
+        val intent = Intent(this@SplashActivity, ExploreActivity::class.java)
+        startActivity(intent)
+        //finish this activity
+        finish()
 
     }
 }

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.mobileforce.hometeach.ui.SplashActivity"
-    android:background="@drawable/splash_screen"/>


### PR DESCRIPTION
This removes the Timer for the `SplashScreen` Activity and deletes the Layout, uses the Launcher Theme instead.
Part of issue #105 

<img src="https://user-images.githubusercontent.com/29807085/87086834-02d2b600-c22a-11ea-8a04-5ab2cc8d7dc2.png" height="700"/>

